### PR TITLE
Reindented hello-world.ast

### DIFF
--- a/hello-world.wast
+++ b/hello-world.wast
@@ -1,15 +1,11 @@
 (module
-  (memory 256 256)
-  (export "memory" memory)
-  (type $FUNCSIG$dd (func (param f64) (result f64)))
-  (import $exp "global.Math" "exp" (param f64) (result f64))
-  (export "doubleExp" $doubleExp)
-  (func $doubleExp (param $0 f64) (result f64)
-    (f64.mul
-      (call_import $exp
-        (get_local $0)
-      )
-      (f64.const 2)
-    )
-  )
-)
+ (memory 256 256)
+ (export "memory" memory)
+ (type $FUNCSIG$dd (func (param f64) (result f64)))
+ (import $exp "global.Math" "exp" (param f64) (result f64))
+ (export "doubleExp" $doubleExp)
+ (func $doubleExp (param $0 f64) (result f64)
+       (f64.mul
+        (call_import $exp
+                     (get_local $0))
+        (f64.const 2))))


### PR DESCRIPTION
S-expressions have a different formatting standard than C-like code; it's actually more readable once one gets used to it.

See e.g. http://mumble.net/~campbell/scheme/style.txt, search for "*** Line Separation" and "*** Parenthetical Philosophy" for rationale.